### PR TITLE
Rename UpdateResouce to ModifyResource

### DIFF
--- a/lib/resources/resource.cpp
+++ b/lib/resources/resource.cpp
@@ -42,7 +42,7 @@ size_t pixelarium::resources::ImageResourcePool::SetResource(unique_ptr<Pixelari
 /// @param id The ID of the resource to update.
 /// @param res A unique pointer to the new resource.
 /// @return True if the resource was updated, false otherwise.
-bool pixelarium::resources::ImageResourcePool::UpdateResource(size_t id, std::unique_ptr<imaging::PixelariumImage> res)
+bool pixelarium::resources::ImageResourcePool::ModifyResource(size_t id, std::unique_ptr<imaging::PixelariumImage> res)
 {
     auto search{this->resources_.find(id)};
     if (search == this->resources_.end()) return false;

--- a/lib/resources/resource.hpp
+++ b/lib/resources/resource.hpp
@@ -11,7 +11,7 @@ namespace pixelarium::resources
 {
 struct IResource
 {
-    virtual ~IResource() = 0;
+    virtual ~IResource() = default;
 };
 
 template <typename R>
@@ -25,7 +25,7 @@ class IResourcePool
     virtual ~IResourcePool() = default;
     virtual std::optional<const R*> GetResource(size_t id) const = 0;
     virtual size_t SetResource(std::unique_ptr<R> res) = 0;
-    virtual bool UpdateResource(size_t id, std::unique_ptr<R> res) = 0;
+    virtual bool ModifyResource(size_t id, std::unique_ptr<R> res) = 0;
     virtual bool DeleteResource(size_t id) = 0;
     virtual void EnumerateResources(const std::function<void(size_t, const R&)>& func) = 0;
 };
@@ -47,7 +47,7 @@ class ImageResourcePool : public IResourcePool<imaging::PixelariumImage>
 
     std::optional<const imaging::PixelariumImage*> GetResource(size_t id) const override;
     size_t SetResource(std::unique_ptr<imaging::PixelariumImage> res) override;
-    bool UpdateResource(size_t id, std::unique_ptr<imaging::PixelariumImage> res) override;
+    bool ModifyResource(size_t id, std::unique_ptr<imaging::PixelariumImage> res) override;
     bool DeleteResource(size_t id) override;
 
     void EnumerateResources(const std::function<void(size_t, const imaging::PixelariumImage&)>& func) override;

--- a/tests/lib/resources/test_resource.cpp
+++ b/tests/lib/resources/test_resource.cpp
@@ -43,22 +43,22 @@ TEST(ImageResourcePoolTest, GetNonExistentResourceReturnsEmptyOptional)
     EXPECT_FALSE(pool.GetResource(12345));
 }
 
-TEST(ImageResourcePoolTest, UpdateResourceSuccess)
+TEST(ImageResourcePoolTest, ModifyResourceSuccess)
 {
     ImageResourcePool pool;
     auto id = pool.SetResource(std::make_unique<DummyImage>());
     auto new_img = std::make_unique<DummyImage>();
-    EXPECT_TRUE(pool.UpdateResource(id, std::move(new_img)));
+    EXPECT_TRUE(pool.ModifyResource(id, std::move(new_img)));
     auto res = pool.GetResource(id);
     EXPECT_TRUE(res.has_value());
     EXPECT_NE(res.value(), nullptr);
 }
 
-TEST(ImageResourcePoolTest, UpdateResourceFail)
+TEST(ImageResourcePoolTest, ModifyResourceFail)
 {
     ImageResourcePool pool;
     auto new_img = std::make_unique<DummyImage>();
-    EXPECT_FALSE(pool.UpdateResource(999, std::move(new_img)));
+    EXPECT_FALSE(pool.ModifyResource(999, std::move(new_img)));
 }
 
 TEST(ImageResourcePoolTest, DeleteResourceSuccess)


### PR DESCRIPTION
For some reason it seems as if UpdateResource is already defined in some (other) dependency of Pixelarium.
Instead of throwing around platform specific macros to fix the Windows build for correct mangling, I decided to simply rename the function.

Fixes #3